### PR TITLE
Preview: notes/currency/budget-alerts features + security & date fixes

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -8,54 +8,72 @@ on:
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Deploy Preview to EC2
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
-          key: ${{ secrets.EC2_SSH_KEY }}
+          password: ${{ secrets.EC2_PASSWORD }}
+          port: ${{ secrets.EC2_PORT }}
+          command_timeout: 30m
           script: |
-            cd /home/ubuntu/projects/Barbie-preview
-            
-            echo "📥 Fetching latest code..."
+            sudo -u ubuntu -H bash <<'EOF'
+            set -euo pipefail
+            export PATH=/usr/local/bin:/usr/bin:/bin:/opt/node-v22.22.2/bin
+            export PM2_HOME=/home/ubuntu/.pm2
+
+            REPO_DIR="/srv/uofa/apps/Barbie-preview"
+            BACKEND_DIR="$REPO_DIR/apps/backend"
+            FRONTEND_DIR="$REPO_DIR/apps/frontend"
+
+            if [ ! -d "$REPO_DIR/.git" ]; then
+              echo "Missing git repository: $REPO_DIR"
+              exit 1
+            fi
+
+            if [ ! -f "$BACKEND_DIR/.env.production.local" ]; then
+              echo "Missing backend env file: $BACKEND_DIR/.env.production.local"
+              exit 1
+            fi
+
+            if ! command -v pm2 >/dev/null 2>&1; then
+              echo "pm2 is required on server"
+              exit 1
+            fi
+
+            cd "$REPO_DIR"
+
+            echo "Fetching latest code..."
             git fetch origin preview
-            
-            echo "🔄 Resetting to latest commit..."
-            git reset --hard origin/preview
-            
-            echo "📦 Installing backend dependencies..."
-            cd apps/backend
-            npm install --production
-            
-            echo "� Configuring backend .env for preview..."
-            # Update PORT from 4273 to 4274 (using regex)
+            git checkout preview
+            git pull --ff-only origin preview
+
+            echo "Installing backend dependencies..."
+            cd "$BACKEND_DIR"
+            npm ci --omit=dev
+
+            echo "Configuring backend .env for preview..."
             sed -i "s/^PORT=.*/PORT=4274/" .env.production.local
-            # Update SERVER_URL to use port 4274 (using regex)
             sed -i "s|^SERVER_URL=.*|SERVER_URL=http://localhost:4274|" .env.production.local
-            # Update FRONTEND_URL for preview path (using regex)
             sed -i "s|^FRONTEND_URL=.*|FRONTEND_URL=https://uofa.ink/preview|" .env.production.local
-            
-            echo "�🔄 Restarting preview backend..."
-            pm2 restart barbie-backend-preview || pm2 start npm --name "barbie-backend-preview" -- start
-            
-            echo "📝 Configuring frontend for preview..."
-            cd ../frontend
-            
-            # 修改 vite.config.js: 端口改为 4274，base 改为 /preview/
-            # Update backend port
+
+            echo "Configuring frontend for preview..."
+            cd "$FRONTEND_DIR"
             sed -i "s/const backendPort = .*;/const backendPort = mode === 'development' ? 5500 : 4274;/" vite.config.js
-            # Comment out root base path
             sed -i "s|.*const base = '/';|  // const base = '/';|" vite.config.js
-            # Uncomment preview base path
             sed -i "s|.*// const base = '/preview/';|  const base = '/preview/';|" vite.config.js
-            
-            echo "📦 Installing frontend dependencies..."
-            npm install
-            
-            echo "🔨 Building frontend..."
+
+            echo "Installing frontend dependencies..."
+            npm ci
+
+            echo "Building frontend..."
             npm run build
-            
-            echo "✅ Preview deployment completed!"
-            echo "🌐 Access at: https://uofa.ink/preview/"
+
+            echo "Restarting preview backend..."
+            pm2 restart barbie-backend-preview --update-env || pm2 start npm --name "barbie-backend-preview" --cwd "$BACKEND_DIR" -- start
+            pm2 save
+
+            echo "Preview deployment completed."
+            EOF

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,35 +8,62 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Deploy to EC2
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
-          key: ${{ secrets.EC2_SSH_KEY }}
+          password: ${{ secrets.EC2_PASSWORD }}
+          port: ${{ secrets.EC2_PORT }}
+          command_timeout: 30m
           script: |
-            cd /home/ubuntu/projects/Barbie
-            
-            echo "📥 Fetching latest code..."
+            sudo -u ubuntu -H bash <<'EOF'
+            set -euo pipefail
+            export PATH=/usr/local/bin:/usr/bin:/bin:/opt/node-v22.22.2/bin
+            export PM2_HOME=/home/ubuntu/.pm2
+
+            REPO_DIR="/srv/uofa/apps/Barbie"
+            BACKEND_DIR="$REPO_DIR/apps/backend"
+            FRONTEND_DIR="$REPO_DIR/apps/frontend"
+
+            if [ ! -d "$REPO_DIR/.git" ]; then
+              echo "Missing git repository: $REPO_DIR"
+              exit 1
+            fi
+
+            if [ ! -f "$BACKEND_DIR/.env.production.local" ]; then
+              echo "Missing backend env file: $BACKEND_DIR/.env.production.local"
+              exit 1
+            fi
+
+            if ! command -v pm2 >/dev/null 2>&1; then
+              echo "pm2 is required on server"
+              exit 1
+            fi
+
+            cd "$REPO_DIR"
+
+            echo "Fetching latest code..."
             git fetch origin main
-            
-            echo "🔄 Resetting to latest commit..."
-            git reset --hard origin/main
-            
-            echo "📦 Installing backend dependencies..."
-            cd apps/backend
-            npm install --production
-            
-            echo "🔄 Restarting backend..."
-            pm2 restart barbie-backend
-            
-            echo "📦 Installing frontend dependencies..."
-            cd ../frontend
-            npm install
-            
-            echo "🔨 Building frontend..."
+            git checkout main
+            git pull --ff-only origin main
+
+            echo "Installing backend dependencies..."
+            cd "$BACKEND_DIR"
+            npm ci --omit=dev
+
+            echo "Installing frontend dependencies..."
+            cd "$FRONTEND_DIR"
+            npm ci
+
+            echo "Building frontend..."
             npm run build
-            
-            echo "✅ Deployment completed!"
+
+            echo "Restarting backend..."
+            pm2 restart barbie-backend --update-env || pm2 start npm --name "barbie-backend" --cwd "$BACKEND_DIR" -- start
+            pm2 save
+
+            echo "Deployment completed."
+            EOF

--- a/apps/backend/src/config/email.js
+++ b/apps/backend/src/config/email.js
@@ -31,8 +31,10 @@ if (NODE_ENV === 'development') {
         },
     });
     console.log('[EMAIL] Using production SMTP');
-    console.log(`[EMAIL_DEBUG] Host: ${EMAIL_HOST}, User: ${EMAIL_USER}`);
-    console.log(`[EMAIL_DEBUG] Pass (first 4): ${EMAIL_PASS ? EMAIL_PASS.substring(0, 4) + '...' : 'MISSING'}`);
+    if (NODE_ENV !== 'production') {
+        console.log(`[EMAIL_DEBUG] Host: ${EMAIL_HOST}, User: ${EMAIL_USER}`);
+        console.log(`[EMAIL_DEBUG] Pass (first 4): ${EMAIL_PASS ? EMAIL_PASS.substring(0, 4) + '...' : 'MISSING'}`);
+    }
 }
 
 // Verify connection on startup

--- a/apps/backend/src/modules/budgets/budget.model.js
+++ b/apps/backend/src/modules/budgets/budget.model.js
@@ -28,7 +28,7 @@ const budgetSchema = new mongoose.Schema(
 
     currency: {
       type: String,
-      enum: ['EUR', 'USD', 'CNY', 'AUD'],
+      match: [/^[A-Z]{3}$/, 'Currency must be a valid 3-letter currency code'],
       default: 'USD',
     },
     amountUSD: {

--- a/apps/backend/src/modules/budgets/budget.validation.js
+++ b/apps/backend/src/modules/budgets/budget.validation.js
@@ -4,13 +4,16 @@ const budgetSchema = Joi.object({
   category: Joi.string()
     .valid('Food', 'Transport', 'Entertainment', 'Utilities', 'Rent', 'Health', 'Others')
     .default('Others')
-    .trim(), 
+    .trim(),
   currency: Joi.string()
-    .valid('EUR', 'USD', 'CNY', 'AUD')
-    .default('USD'),
+    .pattern(/^[A-Z]{3}$/)
+    .default('USD')
+    .messages({
+      'string.pattern.base': 'Currency must be a valid 3-letter currency code (e.g. USD, GBP, JPY)'
+    }),
   limit: Joi.number()
     .min(0)
-    .max(1000000) 
+    .max(1000000)
     .required(),
   month: Joi.number()
     .min(1)

--- a/apps/backend/src/modules/currency/currency.service.js
+++ b/apps/backend/src/modules/currency/currency.service.js
@@ -148,6 +148,12 @@ function aggregateToMonthly(series) {
 }
 
 
+const unsupportedCurrencyError = (currencyCode) => {
+    const err = new Error(`Unsupported currency: ${currencyCode}`);
+    err.statusCode = 400;
+    return err;
+};
+
 export const convertToUSD = async (amount, currencyCode) => {
     if (currencyCode === 'USD') return amount;
 
@@ -155,7 +161,7 @@ export const convertToUSD = async (amount, currencyCode) => {
     const rate = rates[currencyCode];
 
     if (!rate) {
-        throw new Error(`Currency code ${currencyCode} not found`);
+        throw unsupportedCurrencyError(currencyCode);
     }
 
     // Convert to USD: Amount / Rate
@@ -170,7 +176,7 @@ export const convertFromUSD = async (amountUSD, targetCurrency) => {
     const rate = rates[targetCurrency];
 
     if (!rate) {
-        throw new Error(`Currency code ${targetCurrency} not found`);
+        throw unsupportedCurrencyError(targetCurrency);
     }
 
     // Convert from USD: Amount * Rate

--- a/apps/backend/src/modules/expenses/expense.model.js
+++ b/apps/backend/src/modules/expenses/expense.model.js
@@ -17,7 +17,7 @@ const expenseSchema = new mongoose.Schema(
     },
     currency: {
       type: String,
-      enum: ['EUR', 'USD', 'CNY', 'AUD'],
+      match: [/^[A-Z]{3}$/, 'Currency must be a valid 3-letter currency code'],
       default: 'USD',
     },
     amountUSD: {

--- a/apps/backend/src/modules/expenses/expense.validation.js
+++ b/apps/backend/src/modules/expenses/expense.validation.js
@@ -3,7 +3,9 @@ import Joi from "joi";
 export const expenseSchema = Joi.object({
     title: Joi.string().min(2).max(100).required(),
     amount: Joi.number().min(0).required(),
-    currency: Joi.string().valid('EUR', 'USD', 'CNY', 'AUD').default('USD'),
+    currency: Joi.string().pattern(/^[A-Z]{3}$/).default('USD').messages({
+        'string.pattern.base': 'Currency must be a valid 3-letter currency code (e.g. USD, GBP, JPY)'
+    }),
     category: Joi.string().valid('Food', 'Transport', 'Entertainment', 'Utilities', 'Rent', 'Health', 'Others').default('Others'),
     date: Joi.date(),
     notes: Joi.string().allow(""),

--- a/apps/backend/src/modules/income/income.model.js
+++ b/apps/backend/src/modules/income/income.model.js
@@ -12,7 +12,7 @@ const incomeSchema = new mongoose.Schema({
     },
     currency: {
         type: String,
-        enum: ['EUR', 'USD', 'CNY', 'AUD'],
+        match: [/^[A-Z]{3}$/, 'Currency must be a valid 3-letter currency code'],
         default: 'USD',
         required: true
     },

--- a/apps/backend/src/modules/income/income.validator.js
+++ b/apps/backend/src/modules/income/income.validator.js
@@ -10,10 +10,10 @@ const incomeSchema = Joi.object({
             'any.required': 'Amount is required'
         }),
     currency: Joi.string()
-        .valid('EUR', 'USD', 'CNY', 'AUD')
+        .pattern(/^[A-Z]{3}$/)
         .default('USD')
         .messages({
-            'any.only': 'Currency must be one of: EUR, USD, CNY, AUD'
+            'string.pattern.base': 'Currency must be a valid 3-letter currency code (e.g. USD, GBP, JPY)'
         }),
     source: Joi.string()
         .trim()

--- a/apps/backend/src/modules/subscription/subscription.model.js
+++ b/apps/backend/src/modules/subscription/subscription.model.js
@@ -19,7 +19,7 @@ const subscriptionSchema = new mongoose.Schema({
     },
     currency: {
         type: String,
-        enum: ['EUR', 'USD', 'CNY', 'AUD'],
+        match: [/^[A-Z]{3}$/, 'Currency must be a valid 3-letter currency code'],
         default: 'USD',
     },
     frequency: {

--- a/apps/backend/src/modules/subscription/subscription.model.js
+++ b/apps/backend/src/modules/subscription/subscription.model.js
@@ -58,6 +58,10 @@ const subscriptionSchema = new mongoose.Schema({
         //     message: 'start data must be in the past',
         // }
     },
+    notes: {
+        type: String,
+        trim: true,
+    },
     renewalDate: {
         type: Date,
     },

--- a/apps/backend/src/modules/subscription/subscription.routes.js
+++ b/apps/backend/src/modules/subscription/subscription.routes.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import authorize from '../../middlewares/auth.middleware.js';
 import validate from '../../middlewares/validate.middleware.js';
-import { subscriptionSchema } from './subscription.validation.js';
+import { subscriptionSchema, subscriptionUpdateSchema } from './subscription.validation.js';
 import {
     createSubscription,
     getSubscriptions,
@@ -27,7 +27,7 @@ subscriptionRouter.get('/:id', getSubscriptionById);
 
 subscriptionRouter.post('/', validate(subscriptionSchema), createSubscription);
 
-subscriptionRouter.put('/:id', updateSubscription);
+subscriptionRouter.put('/:id', validate(subscriptionUpdateSchema), updateSubscription);
 
 subscriptionRouter.delete('/:id', deleteSubscription);
 

--- a/apps/backend/src/modules/subscription/subscription.validation.js
+++ b/apps/backend/src/modules/subscription/subscription.validation.js
@@ -13,4 +13,5 @@ export const subscriptionSchema = Joi.object({
   status: Joi.string().valid('active', 'cancelled', 'expired').default('active'),
   renewalDate: Joi.date(),
   user: Joi.string().hex().length(24), // ObjectId validation
+  notes: Joi.string().allow('').optional(),
 });

--- a/apps/backend/src/modules/subscription/subscription.validation.js
+++ b/apps/backend/src/modules/subscription/subscription.validation.js
@@ -3,7 +3,9 @@ import Joi from 'joi';
 export const subscriptionSchema = Joi.object({
   name: Joi.string().min(2).max(100).required(),
   price: Joi.number().min(0).required(),
-  currency: Joi.string().valid('EUR', 'USD', 'CNY', 'AUD').default('USD'),
+  currency: Joi.string().pattern(/^[A-Z]{3}$/).default('USD').messages({
+    'string.pattern.base': 'Currency must be a valid 3-letter currency code (e.g. USD, GBP, JPY)'
+  }),
   frequency: Joi.string().valid('daily', 'weekly', 'monthly', 'yearly').required(),
   category: Joi.string().valid('Food', 'Transport', 'Entertainment', 'Utilities', 'Rent', 'Health', 'Others').required(),
   startDate: Joi.date().required(),

--- a/apps/backend/src/modules/subscription/subscription.validation.js
+++ b/apps/backend/src/modules/subscription/subscription.validation.js
@@ -12,6 +12,20 @@ export const subscriptionSchema = Joi.object({
   paymentMethod: Joi.string().required(),
   status: Joi.string().valid('active', 'cancelled', 'expired').default('active'),
   renewalDate: Joi.date(),
-  user: Joi.string().hex().length(24), // ObjectId validation
   notes: Joi.string().allow('').optional(),
 });
+
+export const subscriptionUpdateSchema = Joi.object({
+  name: Joi.string().min(2).max(100),
+  price: Joi.number().min(0),
+  currency: Joi.string().pattern(/^[A-Z]{3}$/).messages({
+    'string.pattern.base': 'Currency must be a valid 3-letter currency code (e.g. USD, GBP, JPY)'
+  }),
+  frequency: Joi.string().valid('daily', 'weekly', 'monthly', 'yearly'),
+  category: Joi.string().valid('Food', 'Transport', 'Entertainment', 'Utilities', 'Rent', 'Health', 'Others'),
+  startDate: Joi.date(),
+  paymentMethod: Joi.string(),
+  status: Joi.string().valid('active', 'cancelled', 'expired'),
+  renewalDate: Joi.date(),
+  notes: Joi.string().allow('').optional(),
+}).min(1);

--- a/apps/backend/tests/budget.refactor.test.js
+++ b/apps/backend/tests/budget.refactor.test.js
@@ -43,6 +43,9 @@ jest.unstable_mockModule('../src/modules/currency/currency.service.js', () => ({
     convertFromUSD: jest.fn((amount) => amount), // Identity for testing
     convertToUSD: jest.fn((amount) => amount)
 }));
+jest.unstable_mockModule('../src/modules/budgets/budgetAlertService.js', () => ({
+    checkBudgetAlerts: jest.fn(() => ({ alerts: [] }))
+}));
 
 // Import Controller
 const {
@@ -177,7 +180,12 @@ describe('Budget Controller (Refactored)', () => {
 
             expect(mockAuthorization.assertOwnerOrAdmin).toHaveBeenCalled();
             expect(mockBudgetRepository.update).toHaveBeenCalledWith('b1', preparedData);
-            console.log('--- TEST PASSED ---');
+            expect(res.json).toHaveBeenCalledWith({
+                success: true,
+                message: "Budget updated successfully",
+                data: updatedBudget,
+                alerts: []
+            });
         });
 
         it('should handle update failure (Budget not found)', async () => {

--- a/apps/backend/tests/currency.crud.test.js
+++ b/apps/backend/tests/currency.crud.test.js
@@ -1,0 +1,458 @@
+import { jest } from '@jest/globals';
+
+/**
+ * Currency CRUD Tests for Uncommon Currencies
+ * 
+ * Tests that income, expense, subscription, and budget modules:
+ * - Accept uncommon currencies (GBP, JPY, BRL, INR, KRW)
+ * - Correctly convert to USD via currency service
+ * - Update currency and recalculate amountUSD
+ * - Statistics/summaries work with mixed currencies
+ * - Validation rejects invalid currency codes
+ */
+
+// Mock Dependencies
+const mockIncomeRepository = {
+    find: jest.fn(),
+    findById: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    deleteById: jest.fn(),
+    aggregate: jest.fn()
+};
+
+const mockExpenseRepository = {
+    create: jest.fn(),
+    findById: jest.fn(),
+    findByUser: jest.fn(),
+    update: jest.fn(),
+    deleteById: jest.fn(),
+    aggregate: jest.fn()
+};
+
+const mockSubscriptionRepository = {
+    find: jest.fn(),
+    findById: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    deleteById: jest.fn(),
+    aggregate: jest.fn()
+};
+
+const mockBudgetRepository = {
+    find: jest.fn(),
+    findById: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    deleteById: jest.fn(),
+    aggregate: jest.fn()
+};
+
+const mockIncomeService = {
+    prepareIncomeData: jest.fn(),
+    buildMonthlyStatsPipeline: jest.fn()
+};
+
+const mockExpenseService = {
+    prepareExpenseData: jest.fn(),
+    buildMonthlyStatsPipeline: jest.fn()
+};
+
+const mockSubscriptionService = {
+    prepareSubscriptionData: jest.fn(),
+    buildTotalSubscriptionPipeline: jest.fn(),
+    calculateTotalFromStats: jest.fn()
+};
+
+const mockBudgetService = {
+    prepareBudgetData: jest.fn(),
+    buildMonthlyStatsPipeline: jest.fn()
+};
+
+const mockAuthorization = {
+    assertOwnerOrAdmin: jest.fn(),
+    assertSameUserOrAdmin: jest.fn(),
+    buildError: jest.fn((msg, code) => {
+        const err = new Error(msg);
+        err.statusCode = code;
+        return err;
+    })
+};
+
+// Mock currency conversion rates for testing
+const mockCurrencyService = {
+    convertFromUSD: jest.fn((amount, currency) => {
+        const rates = {
+            'USD': 1,
+            'GBP': 0.79,
+            'JPY': 149.5,
+            'BRL': 4.92,
+            'INR': 83.12,
+            'KRW': 1337.5
+        };
+        return amount * (rates[currency] || 1);
+    }),
+    convertToUSD: jest.fn((amount, currency) => {
+        const rates = {
+            'USD': 1,
+            'GBP': 0.79,
+            'JPY': 149.5,
+            'BRL': 4.92,
+            'INR': 83.12,
+            'KRW': 1337.5
+        };
+        return amount / (rates[currency] || 1);
+    })
+};
+
+// Mock Imports
+jest.unstable_mockModule('../src/modules/income/income.repository.js', () => mockIncomeRepository);
+jest.unstable_mockModule('../src/modules/income/income.services.js', () => mockIncomeService);
+jest.unstable_mockModule('../src/modules/expenses/expense.repository.js', () => mockExpenseRepository);
+jest.unstable_mockModule('../src/modules/expenses/expense.service.js', () => mockExpenseService);
+jest.unstable_mockModule('../src/modules/subscription/subscription.repository.js', () => mockSubscriptionRepository);
+jest.unstable_mockModule('../src/modules/subscription/subscription.service.js', () => mockSubscriptionService);
+jest.unstable_mockModule('../src/modules/budgets/budget.repository.js', () => mockBudgetRepository);
+jest.unstable_mockModule('../src/modules/budgets/budget.services.js', () => mockBudgetService);
+jest.unstable_mockModule('../src/utils/authorization.js', () => mockAuthorization);
+jest.unstable_mockModule('../src/modules/currency/currency.service.js', () => mockCurrencyService);
+jest.unstable_mockModule('../src/modules/budgets/budgetAlertService.js', () => ({
+    checkBudgetAlerts: jest.fn(() => ({ alerts: [] }))
+}));
+
+// Import Controllers
+const { createIncome, updateIncome, getIncomeSummary } = await import('../src/modules/income/income.controllers.js');
+const { createExpenseController, updateExpenseController } = await import('../src/modules/expenses/expense.controller.js');
+const { createSubscription, updateSubscription, getTotalSubscription } = await import('../src/modules/subscription/subscription.controller.js');
+const { createBudgetController, updateBudgetController, getBudgetStatisticsController } = await import('../src/modules/budgets/budget.controllers.js');
+
+describe('Uncommon Currency Support', () => {
+    let req, res, next;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        req = {
+            body: {},
+            user: { _id: 'user123', role: 'user', defaultCurrency: 'USD' },
+            params: {},
+            query: {}
+        };
+        res = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn(),
+            send: jest.fn()
+        };
+        next = jest.fn();
+    });
+
+    describe('Income with uncommon currencies', () => {
+        it('should create income with GBP currency', async () => {
+            req.body = { amount: 1000, currency: 'GBP', category: 'Salary', date: new Date() };
+
+            const preparedData = {
+                amount: 1000,
+                currency: 'GBP',
+                amountUSD: 1265.82, // 1000 / 0.79
+                category: 'Salary',
+                user: 'user123',
+                date: req.body.date
+            };
+            const createdIncome = { ...preparedData, _id: 'inc1' };
+
+            mockIncomeService.prepareIncomeData.mockResolvedValue(preparedData);
+            mockIncomeRepository.create.mockResolvedValue(createdIncome);
+
+            await createIncome(req, res, next);
+
+            expect(mockIncomeService.prepareIncomeData).toHaveBeenCalledWith(expect.objectContaining({
+                amount: 1000,
+                currency: 'GBP'
+            }));
+            expect(res.status).toHaveBeenCalledWith(201);
+            expect(res.json).toHaveBeenCalledWith({
+                success: true,
+                message: "Income created successfully",
+                data: createdIncome
+            });
+        });
+
+        it('should update income currency from USD to JPY and recalculate amountUSD', async () => {
+            req.params.id = 'inc1';
+            req.body = { amount: 149500, currency: 'JPY' };
+
+            const existingIncome = { _id: 'inc1', user: 'user123', amount: 1000, currency: 'USD', amountUSD: 1000 };
+            const preparedData = { amount: 149500, currency: 'JPY', amountUSD: 1000 }; // 149500 / 149.5
+            const updatedIncome = { ...existingIncome, ...preparedData };
+
+            mockIncomeRepository.findById.mockResolvedValue(existingIncome);
+            mockIncomeService.prepareIncomeData.mockResolvedValue(preparedData);
+            mockIncomeRepository.update.mockResolvedValue(updatedIncome);
+
+            await updateIncome(req, res, next);
+
+            expect(mockIncomeService.prepareIncomeData).toHaveBeenCalled();
+            expect(res.json).toHaveBeenCalledWith({
+                success: true,
+                message: "Income updated successfully",
+                data: updatedIncome
+            });
+        });
+    });
+
+    describe('Expense with uncommon currencies', () => {
+        it('should create expense with BRL currency', async () => {
+            req.body = { title: 'Groceries', amount: 492, currency: 'BRL', category: 'Food', date: new Date() };
+
+            const processedData = {
+                title: 'Groceries',
+                amount: 492,
+                currency: 'BRL',
+                amountUSD: 100, // 492 / 4.92
+                category: 'Food',
+                date: req.body.date
+            };
+            const createdExpense = { ...processedData, _id: 'exp1', user: 'user123', toJSON: () => processedData };
+
+            mockExpenseService.prepareExpenseData.mockResolvedValue(processedData);
+            mockExpenseRepository.create.mockResolvedValue(createdExpense);
+
+            await createExpenseController(req, res, next);
+
+            expect(mockExpenseService.prepareExpenseData).toHaveBeenCalledWith(expect.objectContaining({
+                amount: 492,
+                currency: 'BRL'
+            }));
+            expect(res.status).toHaveBeenCalledWith(201);
+        });
+
+        it('should update expense amount with BRL and recalculate amountUSD', async () => {
+            req.params.id = 'exp1';
+            req.body = { amount: 984 }; // Double the amount
+
+            const testDate = new Date('2026-02-15');
+            const existingExpense = { _id: 'exp1', user: 'user123', amount: 492, currency: 'BRL', amountUSD: 100, date: testDate, category: 'Food' };
+            const processedData = { amount: 984, amountUSD: 200 }; // 984 / 4.92
+            const updatedExpense = {
+                ...existingExpense,
+                ...processedData,
+                toJSON: function () {
+                    const { toJSON, ...rest } = this;
+                    return rest;
+                }
+            };
+
+            mockExpenseRepository.findById.mockResolvedValue(existingExpense);
+            mockExpenseService.prepareExpenseData.mockResolvedValue(processedData);
+            mockExpenseRepository.update.mockResolvedValue(updatedExpense);
+
+            await updateExpenseController(req, res, next);
+
+            expect(mockExpenseService.prepareExpenseData).toHaveBeenCalledWith(req.body, existingExpense);
+            // Note: expense controller returns { ...expense.toJSON(), alerts }
+            expect(res.json).toHaveBeenCalled();
+            const jsonCall = res.json.mock.calls[0][0];
+            expect(jsonCall).toHaveProperty('alerts', []);
+            expect(jsonCall._id).toBe('exp1');
+            expect(jsonCall.amount).toBe(984);
+        });
+    });
+
+    describe('Subscription with uncommon currencies', () => {
+        it('should create subscription with INR currency', async () => {
+            req.body = {
+                name: 'Netflix India',
+                price: 831.2,
+                currency: 'INR',
+                frequency: 'monthly',
+                category: 'Entertainment',
+                startDate: new Date(),
+                paymentMethod: 'Credit Card'
+            };
+
+            const preparedData = {
+                ...req.body,
+                amountUSD: 10, // 831.2 / 83.12
+                user: 'user123',
+                renewalDate: new Date()
+            };
+            const createdSub = { ...preparedData, _id: 's1' };
+
+            mockSubscriptionService.prepareSubscriptionData.mockResolvedValue(preparedData);
+            mockSubscriptionRepository.create.mockResolvedValue(createdSub);
+
+            await createSubscription(req, res, next);
+
+            expect(mockSubscriptionService.prepareSubscriptionData).toHaveBeenCalledWith(expect.objectContaining({
+                price: 831.2,
+                currency: 'INR'
+            }));
+            expect(res.status).toHaveBeenCalledWith(201);
+        });
+
+        it('should update subscription currency from INR to KRW', async () => {
+            req.params.id = 's1';
+            req.body = { price: 13375, currency: 'KRW' };
+
+            const existing = { _id: 's1', user: 'user123', price: 831.2, currency: 'INR', amountUSD: 10 };
+            const prepared = { price: 13375, currency: 'KRW', amountUSD: 10 }; // 13375 / 1337.5
+            const updated = { ...existing, ...prepared };
+
+            mockSubscriptionRepository.findById.mockResolvedValue(existing);
+            mockSubscriptionService.prepareSubscriptionData.mockResolvedValue(prepared);
+            mockSubscriptionRepository.update.mockResolvedValue(updated);
+
+            await updateSubscription(req, res, next);
+
+            expect(mockSubscriptionService.prepareSubscriptionData).toHaveBeenCalled();
+            expect(res.json).toHaveBeenCalledWith({
+                success: true,
+                message: 'Subscription updated successfully',
+                data: { subscription: updated }
+            });
+        });
+    });
+
+    describe('Budget with uncommon currencies', () => {
+        it('should create budget with JPY currency', async () => {
+            req.body = {
+                limit: 149500,
+                currency: 'JPY',
+                category: 'Food',
+                month: 2,
+                year: 2026
+            };
+
+            const preparedData = {
+                ...req.body,
+                amountUSD: 1000, // 149500 / 149.5
+                user: 'user123'
+            };
+            const createdBudget = { ...preparedData, _id: 'b1' };
+
+            mockBudgetService.prepareBudgetData.mockResolvedValue(preparedData);
+            mockBudgetRepository.create.mockResolvedValue(createdBudget);
+
+            await createBudgetController(req, res, next);
+
+            expect(mockBudgetService.prepareBudgetData).toHaveBeenCalledWith(expect.objectContaining({
+                limit: 149500,
+                currency: 'JPY'
+            }));
+            expect(res.status).toHaveBeenCalledWith(201);
+        });
+
+        it('should update budget limit with KRW currency', async () => {
+            req.params.id = 'b1';
+            req.body = { limit: 26750 }; // Double the limit
+
+            const existingBudget = { _id: 'b1', user: 'user123', limit: 13375, currency: 'KRW', amountUSD: 10 };
+            const preparedData = { limit: 26750, amountUSD: 20 }; // 26750 / 1337.5
+            const updatedBudget = { ...existingBudget, ...preparedData };
+
+            mockBudgetRepository.findById.mockResolvedValue(existingBudget);
+            mockBudgetService.prepareBudgetData.mockResolvedValue(preparedData);
+            mockBudgetRepository.update.mockResolvedValue(updatedBudget);
+
+            await updateBudgetController(req, res, next);
+
+            expect(mockBudgetService.prepareBudgetData).toHaveBeenCalled();
+            expect(res.json).toHaveBeenCalledWith({
+                success: true,
+                message: "Budget updated successfully",
+                data: updatedBudget,
+                alerts: []
+            });
+        });
+    });
+
+    describe('Statistics with mixed currencies', () => {
+        it('should calculate income summary with user default currency GBP', async () => {
+            req.query = { month: '2', year: '2026' };
+            req.user.defaultCurrency = 'GBP';
+
+            const pipeline = ['pipeline'];
+            // Income in different currencies, all converted to USD in DB
+            const stats = [
+                { _id: 'Salary', totalAmount: 1000, count: 1 }, // 1000 USD
+                { _id: 'Freelance', totalAmount: 500, count: 2 }  // 500 USD
+            ];
+
+            mockIncomeService.buildMonthlyStatsPipeline.mockReturnValue(pipeline);
+            mockIncomeRepository.aggregate.mockResolvedValue(stats);
+
+            await getIncomeSummary(req, res, next);
+
+            // Should convert USD totals to GBP
+            expect(mockCurrencyService.convertFromUSD).toHaveBeenCalledWith(1500, 'GBP');
+            expect(res.json).toHaveBeenCalledWith({
+                success: true,
+                data: {
+                    totalIncome: 1185, // 1500 USD * 0.79 = 1185 GBP
+                    categoryBreakdown: [
+                        { category: 'Salary', total: 790, count: 1 },  // 1000 * 0.79
+                        { category: 'Freelance', total: 395, count: 2 } // 500 * 0.79
+                    ]
+                }
+            });
+        });
+
+        it('should calculate budget statistics with mixed currencies in KRW budget and INR expenses', async () => {
+            req.query = { month: '2', year: '2026' };
+            req.user.defaultCurrency = 'KRW';
+
+            const bPipeline = ['budget_pipe'];
+            const ePipeline = ['expense_pipe'];
+
+            // Budget in KRW -> converted to USD in DB
+            const budgetStats = [{ _id: 'Food', totalBudgetUSD: 100 }]; // Originally 133750 KRW
+            // Expenses in INR -> converted to USD in DB
+            const expenseStats = [{ _id: 'Food', totalExpensesUSD: 50 }]; // Originally 4156 INR
+
+            mockBudgetService.buildMonthlyStatsPipeline.mockReturnValue(bPipeline);
+            mockExpenseService.buildMonthlyStatsPipeline.mockReturnValue(ePipeline);
+            mockBudgetRepository.aggregate.mockResolvedValue(budgetStats);
+            mockExpenseRepository.aggregate.mockResolvedValue(expenseStats);
+
+            await getBudgetStatisticsController(req, res, next);
+
+            // Should convert both budgets and expenses from USD to KRW
+            expect(mockCurrencyService.convertFromUSD).toHaveBeenCalled();
+            expect(mockBudgetRepository.aggregate).toHaveBeenCalledWith(bPipeline);
+            expect(mockExpenseRepository.aggregate).toHaveBeenCalledWith(ePipeline);
+        });
+    });
+
+    describe('Currency validation', () => {
+        it('should reject lowercase currency code', async () => {
+            req.body = { amount: 1000, currency: 'gbp', category: 'Salary', date: new Date() };
+
+            // The Joi validator should catch this before reaching the service
+            // In a real scenario, this would be caught by middleware
+            // For this test, we're documenting expected behavior
+
+            // Note: This test demonstrates what SHOULD happen with validation
+            // The actual validation occurs in the route middleware with Joi
+            expect('gbp').not.toMatch(/^[A-Z]{3}$/);
+        });
+
+        it('should reject 2-letter currency code', async () => {
+            expect('US').not.toMatch(/^[A-Z]{3}$/);
+        });
+
+        it('should reject 4-letter currency code', async () => {
+            expect('USDD').not.toMatch(/^[A-Z]{3}$/);
+        });
+
+        it('should reject currency code with numbers', async () => {
+            expect('US1').not.toMatch(/^[A-Z]{3}$/);
+        });
+
+        it('should accept valid 3-letter uppercase currency codes', async () => {
+            const validCurrencies = ['USD', 'GBP', 'JPY', 'BRL', 'INR', 'KRW', 'EUR', 'CNY', 'AUD', 'CAD', 'CHF'];
+
+            validCurrencies.forEach(currency => {
+                expect(currency).toMatch(/^[A-Z]{3}$/);
+            });
+        });
+    });
+});

--- a/apps/backend/tests/currency.service.test.js
+++ b/apps/backend/tests/currency.service.test.js
@@ -1,0 +1,64 @@
+import { jest } from '@jest/globals';
+
+const mockAxios = {
+    get: jest.fn()
+};
+
+jest.unstable_mockModule('axios', () => ({
+    default: mockAxios
+}));
+
+const { convertToUSD, convertFromUSD } = await import('../src/modules/currency/currency.service.js');
+
+describe('currency.service unsupported currency handling', () => {
+    beforeEach(() => {
+        mockAxios.get.mockReset();
+        mockAxios.get.mockResolvedValue({
+            data: {
+                rates: { USD: 1, EUR: 0.92, GBP: 0.79 }
+            }
+        });
+    });
+
+    describe('convertToUSD', () => {
+        it('returns the amount unchanged for USD', async () => {
+            await expect(convertToUSD(100, 'USD')).resolves.toBe(100);
+        });
+
+        it('converts a supported currency', async () => {
+            await expect(convertToUSD(92, 'EUR')).resolves.toBe(100);
+        });
+
+        it('throws an error with statusCode 400 for an unsupported currency', async () => {
+            expect.assertions(3);
+            try {
+                await convertToUSD(100, 'XYZ');
+            } catch (err) {
+                expect(err).toBeInstanceOf(Error);
+                expect(err.statusCode).toBe(400);
+                expect(err.message).toBe('Unsupported currency: XYZ');
+            }
+        });
+    });
+
+    describe('convertFromUSD', () => {
+        it('returns the amount unchanged for USD', async () => {
+            await expect(convertFromUSD(100, 'USD')).resolves.toBe(100);
+        });
+
+        it('converts to a supported currency', async () => {
+            await expect(convertFromUSD(100, 'EUR')).resolves.toBe(92);
+        });
+
+        it('throws an error with statusCode 400 for an unsupported currency', async () => {
+            expect.assertions(3);
+            try {
+                await convertFromUSD(100, 'XYZ');
+            } catch (err) {
+                expect(err).toBeInstanceOf(Error);
+                expect(err.statusCode).toBe(400);
+                expect(err.message).toBe('Unsupported currency: XYZ');
+            }
+        });
+    });
+});

--- a/apps/backend/tests/expense.refactor.test.js
+++ b/apps/backend/tests/expense.refactor.test.js
@@ -157,7 +157,16 @@ describe('Expense Controller (Refactored)', () => {
             const processedData = { amount: 200, amountUSD: 200 };
             console.log('Mock Setup (Service prepareExpenseData) returns:', JSON.stringify(processedData, null, 2));
 
-            const updatedExpense = { ...existingExpense, ...processedData };
+            const updatedExpense = {
+                ...existingExpense,
+                ...processedData,
+                category: 'Food',
+                date: new Date(),
+                toJSON: function () {
+                    const { toJSON, ...rest } = this;
+                    return rest;
+                }
+            };
             console.log('Mock Setup (Repository update) returns:', JSON.stringify(updatedExpense, null, 2));
 
             mockExpenseRepository.findById.mockResolvedValue(existingExpense);
@@ -171,11 +180,13 @@ describe('Expense Controller (Refactored)', () => {
             expect(mockExpenseService.prepareExpenseData).toHaveBeenCalledWith(req.body, existingExpense);
             expect(mockExpenseRepository.update).toHaveBeenCalledWith('exp1', processedData);
 
-            console.log('Expected Output (res.json):', JSON.stringify(updatedExpense, null, 2));
+            // Now we expect the response to include alerts field
+            const expectedResponse = { ...updatedExpense.toJSON(), alerts: [] };
+            console.log('Expected Output (res.json):', JSON.stringify(expectedResponse, null, 2));
             const actualJson = res.json.mock.calls[0][0];
             console.log('Actual Output (res.json):', JSON.stringify(actualJson, null, 2));
 
-            expect(res.json).toHaveBeenCalledWith(updatedExpense);
+            expect(res.json).toHaveBeenCalledWith(expectedResponse);
             console.log('--- TEST PASSED ---\n');
         });
 

--- a/apps/backend/tests/services/subscription_notes.test.js
+++ b/apps/backend/tests/services/subscription_notes.test.js
@@ -1,0 +1,85 @@
+import { jest } from '@jest/globals';
+
+// Mock currency conversion
+const mockConvertToUSD = jest.fn();
+const mockBuildError = jest.fn((msg, code) => {
+    const err = new Error(msg);
+    err.statusCode = code;
+    return err;
+});
+
+jest.unstable_mockModule('../../src/modules/currency/currency.service.js', () => ({
+    convertToUSD: mockConvertToUSD
+}));
+
+jest.unstable_mockModule('../../src/utils/authorization.js', () => ({
+    buildError: mockBuildError
+}));
+
+// Import service (after mocks)
+const {
+    prepareSubscriptionData
+} = await import('../../src/modules/subscription/subscription.service.js');
+
+describe('Subscription Service - Notes', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockConvertToUSD.mockImplementation((amount, currency) => {
+            return Promise.resolve(amount);
+        });
+    });
+
+    it('should pass notes field through to processed data', async () => {
+        const data = {
+            price: 10,
+            currency: 'USD',
+            startDate: '2024-01-01',
+            frequency: 'monthly',
+            notes: 'Test note for subscription'
+        };
+
+        const result = await prepareSubscriptionData(data);
+
+        expect(result.notes).toBe('Test note for subscription');
+        expect(result.renewalDate).toBeDefined(); // Ensure renewal date logic still works
+    });
+
+    it('should handle undefined notes', async () => {
+        const data = {
+            price: 10,
+            currency: 'USD',
+            startDate: '2024-01-01',
+            frequency: 'monthly'
+        };
+
+        const result = await prepareSubscriptionData(data);
+
+        expect(result.notes).toBeUndefined();
+    });
+
+    it('should preserve existing notes on update if not provided', async () => {
+        const data = { price: 20 };
+        const existingData = {
+            notes: 'Existing note',
+            price: 10,
+            currency: 'USD',
+            startDate: new Date('2024-01-01')
+        };
+
+        const result = await prepareSubscriptionData(data, existingData);
+
+        // The service currently does strict spread of data, lets check behavior.
+        // Looking at service: const processedData = { ...data };
+        // It does NOT automatically merge existingData into processedData for fields not in data, 
+        // EXCEPT for specific logic (price, currency, startDate for renewal calc).
+        // So if I send only price, 'notes' will NOT be in processedData return unless I manually text it.
+        // Wait, the controller usually handles merging or partial updates?
+        // Let's re-read the controller update method.
+        // Controller: const updateData = await subscriptionService.prepareSubscriptionData(req.body, existingSubscription);
+        //             const subscription = await subscriptionRepository.update(subscriptionId, updateData);
+        // The repository update likely does a $set or similar.
+        // If prepareSubscriptionData returns only the *changes*, that's fine.
+
+        expect(result.notes).toBeUndefined(); // Because it wasn't in the input data
+    });
+});

--- a/apps/backend/tests/subscription.validation.test.js
+++ b/apps/backend/tests/subscription.validation.test.js
@@ -1,0 +1,86 @@
+import { subscriptionSchema, subscriptionUpdateSchema } from '../src/modules/subscription/subscription.validation.js';
+
+const validBase = {
+    name: 'Netflix',
+    price: 15.99,
+    currency: 'USD',
+    frequency: 'monthly',
+    category: 'Entertainment',
+    startDate: '2026-01-01',
+    paymentMethod: 'card',
+};
+
+describe('subscriptionSchema (create)', () => {
+    it('accepts a valid payload', () => {
+        const { error } = subscriptionSchema.validate(validBase);
+        expect(error).toBeUndefined();
+    });
+
+    it('rejects an unknown user field (mass-assignment guard)', () => {
+        const { error } = subscriptionSchema.validate({
+            ...validBase,
+            user: '507f1f77bcf86cd799439011',
+        });
+        expect(error).toBeDefined();
+        expect(error.details[0].path).toContain('user');
+    });
+});
+
+describe('subscriptionUpdateSchema (PUT)', () => {
+    it('accepts a partial update with a single field', () => {
+        const { error } = subscriptionUpdateSchema.validate({ name: 'New Name' });
+        expect(error).toBeUndefined();
+    });
+
+    it('accepts an update with several optional fields', () => {
+        const { error } = subscriptionUpdateSchema.validate({
+            price: 9.99,
+            currency: 'EUR',
+            notes: 'cheaper plan',
+        });
+        expect(error).toBeUndefined();
+    });
+
+    it('rejects an empty body', () => {
+        const { error } = subscriptionUpdateSchema.validate({});
+        expect(error).toBeDefined();
+    });
+
+    it('rejects a user field (cannot reassign ownership)', () => {
+        const { error } = subscriptionUpdateSchema.validate({
+            name: 'New Name',
+            user: '507f1f77bcf86cd799439011',
+        });
+        expect(error).toBeDefined();
+        expect(error.details[0].path).toContain('user');
+    });
+
+    it('rejects unknown fields', () => {
+        const { error } = subscriptionUpdateSchema.validate({
+            name: 'New Name',
+            isAdmin: true,
+        });
+        expect(error).toBeDefined();
+    });
+
+    it('rejects an invalid currency code', () => {
+        const { error } = subscriptionUpdateSchema.validate({ currency: 'usd' });
+        expect(error).toBeDefined();
+        expect(error.details[0].path).toContain('currency');
+    });
+
+    it('rejects an invalid frequency', () => {
+        const { error } = subscriptionUpdateSchema.validate({ frequency: 'biweekly' });
+        expect(error).toBeDefined();
+    });
+
+    it('rejects a negative price', () => {
+        const { error } = subscriptionUpdateSchema.validate({ price: -1 });
+        expect(error).toBeDefined();
+    });
+
+    it('allows updating only renewalDate', () => {
+        const { error } = subscriptionUpdateSchema.validate({ renewalDate: '2026-12-31' });
+        expect(error).toBeUndefined();
+    });
+});

--- a/apps/frontend/src/components/common/RecordModal.jsx
+++ b/apps/frontend/src/components/common/RecordModal.jsx
@@ -277,7 +277,18 @@ export default function RecordModal({
                                 />
                             </div>
                         </div>
-                    </div>
+
+                        <div>
+                            <label className={labelClass}>Notes</label>
+                            <textarea
+                                className={inputClass}
+                                rows={3}
+                                value={data.notes ?? ''}
+                                onChange={(e) => onChange('notes', e.target.value)}
+                                placeholder="Add details..."
+                            />
+                        </div>
+                    </div >
                 )
 
             case 'income':

--- a/apps/frontend/src/data/changelogData.js
+++ b/apps/frontend/src/data/changelogData.js
@@ -3,6 +3,16 @@
 
 export const changelog = [
     {
+        version: "1.12.0",
+        date: "2026-02-10",
+        changes: [
+            "Pre-filled 'Today' date for new Expenses, Incomes, and Subscriptions",
+            "Real-time budget alerts when creating or updating expenses",
+            "Remove restriction of only create expenses in existing budgets",
+            "Budget status alerts when modifying budget limits"
+        ]
+    },
+    {
         version: "1.11.0",
         date: "2026-02-09",
         changes: [

--- a/apps/frontend/src/pages/CreateEntries.jsx
+++ b/apps/frontend/src/pages/CreateEntries.jsx
@@ -49,6 +49,15 @@ const incomeCategories = [
   'Other',
 ]
 
+// Helper function to get today's date in YYYY-MM-DD format for date inputs
+const getTodayString = () => {
+  const today = new Date()
+  const year = today.getFullYear()
+  const month = String(today.getMonth() + 1).padStart(2, '0')
+  const day = String(today.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
 const initialSubscription = {
   name: '',
   price: '',
@@ -57,7 +66,7 @@ const initialSubscription = {
   category: '',
   paymentMethod: '',
   status: 'active',
-  startDate: '',
+  startDate: getTodayString(),
   renewalDate: '',
 }
 
@@ -66,7 +75,7 @@ const initialExpense = {
   amount: '',
   currency: 'USD',
   category: '',
-  date: '',
+  date: getTodayString(),
   notes: '',
 }
 
@@ -84,7 +93,7 @@ const initialIncome = {
   currency: 'USD',
   source: '',
   category: '',
-  date: '',
+  date: getTodayString(),
   notes: '',
 }
 

--- a/apps/frontend/src/pages/CreateEntries.jsx
+++ b/apps/frontend/src/pages/CreateEntries.jsx
@@ -236,26 +236,6 @@ function CreateEntries() {
 
     setLoading(true)
     try {
-      // Parse date string (YYYY-MM-DD) directly to avoid timezone issues of "new Date(string)"
-      // which defaults to UTC for hyphenated strings, causing day shifts in local time.
-      const [y, m] = expenseForm.date.split('-')
-      const year = Number(y)
-      const month = Number(m)
-
-      // Check if budget exists for this category and month/year
-      const budgets = await listBudgets({ month, year, userId })
-      const budgetExists = budgets.some(
-        (b) => b.category === expenseForm.category
-      )
-
-      if (!budgetExists) {
-        const errorMsg = `Please set a budget for ${expenseForm.category} before creating an expense.`
-        setMessage(errorMsg)
-        setIsError(true)
-        setLoading(false)
-        throw new Error(errorMsg)
-      }
-
       const response = await createExpense({
         ...expenseForm,
         amount: Number(expenseForm.amount),

--- a/apps/frontend/src/pages/CreateEntries.jsx
+++ b/apps/frontend/src/pages/CreateEntries.jsx
@@ -67,7 +67,7 @@ const initialSubscription = {
   paymentMethod: '',
   status: 'active',
   startDate: getTodayString(),
-  renewalDate: '',
+  notes: '',
 }
 
 const initialExpense = {
@@ -171,7 +171,7 @@ function CreateEntries() {
       await createSubscription({
         ...subscriptionForm,
         price: Number(subscriptionForm.price),
-        renewalDate: subscriptionForm.renewalDate || undefined,
+        notes: subscriptionForm.notes,
       })
       setMessage('Subscription created successfully')
       setIsError(false)
@@ -620,13 +620,13 @@ function CreateEntries() {
               }
               required
             />
-            <input
-              className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm"
-              type="date"
-              placeholder="Renewal date"
-              value={subscriptionForm.renewalDate}
+
+            <textarea
+              className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm sm:col-span-2"
+              placeholder="Notes"
+              value={subscriptionForm.notes}
               onChange={(e) =>
-                handleSubscriptionChange('renewalDate', e.target.value)
+                handleSubscriptionChange('notes', e.target.value)
               }
             />
           </div>

--- a/apps/frontend/src/pages/CreateEntries.jsx
+++ b/apps/frontend/src/pages/CreateEntries.jsx
@@ -79,13 +79,15 @@ const initialExpense = {
   notes: '',
 }
 
-const today = new Date()
-const initialBudget = {
-  category: '',
-  limit: '',
-  month: today.getMonth() + 1,
-  year: today.getFullYear(),
-  currency: 'USD',
+const getInitialBudget = () => {
+  const today = new Date()
+  return {
+    category: '',
+    limit: '',
+    month: today.getMonth() + 1,
+    year: today.getFullYear(),
+    currency: 'USD',
+  }
 }
 
 const initialIncome = {
@@ -125,7 +127,7 @@ function CreateEntries() {
     currency: defaultCurrency
   }))
   const [budgetForm, setBudgetForm] = useState(() => ({
-    ...initialBudget,
+    ...getInitialBudget(),
     currency: defaultCurrency
   }))
   const [incomeForm, setIncomeForm] = useState(() => ({
@@ -211,7 +213,7 @@ function CreateEntries() {
       })
       setMessage('Budget created successfully')
       setIsError(false)
-      setBudgetForm({ ...initialBudget, currency: defaultCurrency })
+      setBudgetForm({ ...getInitialBudget(), currency: defaultCurrency })
       // Invalidate cache so other pages refetch
       queryClient.invalidateQueries({ queryKey: budgetKeys.all })
       queryClient.invalidateQueries({ queryKey: analyticsKeys.all })

--- a/apps/frontend/src/pages/Records.jsx
+++ b/apps/frontend/src/pages/Records.jsx
@@ -165,6 +165,7 @@ function Records() {
               status: item.status ?? 'active',
               startDate: formatDateInput(item.startDate),
               renewalDate: formatDateInput(item.renewalDate),
+              notes: item.notes ?? '',
             },
           ]
         }),

--- a/apps/frontend/src/pages/Records.jsx
+++ b/apps/frontend/src/pages/Records.jsx
@@ -89,6 +89,7 @@ function Records() {
   const setYear = useStore((state) => state.setSelectedYear)
 
   const [error, setError] = useState('')
+  const [alerts, setAlerts] = useState([])
   const [expenseEdits, setExpenseEdits] = useState({})
   const [subscriptionEdits, setSubscriptionEdits] = useState({})
   const [budgetEdits, setBudgetEdits] = useState({})
@@ -242,6 +243,7 @@ function Records() {
 
   const handleUpdateExpense = async (id) => {
     setError('')
+    setAlerts([])
     const payload = expenseEdits[id]
     if (!payload) return
 
@@ -250,58 +252,23 @@ function Records() {
       throw new Error('Validation failed')
     }
 
-    // Budget check
-    if (payload.date && payload.category) {
-      // Parse date string (YYYY-MM-DD) directly to avoid timezone issues
-      let expMonth, expYear
-      // Handle partial date strings or full ISO strings if they occur (though payload.date is usually YYYY-MM-DD from input)
-      if (payload.date.includes('T')) {
-        const d = new Date(payload.date)
-        expMonth = d.getMonth() + 1
-        expYear = d.getFullYear()
-      } else {
-        const [y, m] = payload.date.split('-')
-        expYear = Number(y)
-        expMonth = Number(m)
-      }
-
-      let relevantBudgets = []
-      // If the expense date falls in the currently viewed month/year, we can use the local state
-      if (expMonth === month && expYear === year) {
-        relevantBudgets = budgets
-      } else {
-        // Otherwise we need to fetch the budgets for that time period
-        try {
-          relevantBudgets = await listBudgets({
-            month: expMonth,
-            year: expYear,
-            userId,
-          })
-        } catch {
-          // If fetch fails, we can't verify, so we might choose to block or warn. 
-          // For now let's assume empty to result in blocking to be safe?
-          // Or strictly follow requirements: "ask them to set a budget first" -> implies blocking.
-          relevantBudgets = []
-        }
-      }
-
-      const budgetExists = relevantBudgets.some(
-        (b) => b.category === payload.category
-      )
-
-      if (!budgetExists) {
-        setError(
-          `Please set a budget for ${payload.category} before updating this expense.`
-        )
-        throw new Error('Budget missing')
-      }
-    }
-
     try {
-      await updateExpense(id, {
+      const response = await updateExpense(id, {
         ...payload,
         amount: Number(payload.amount),
       })
+
+      // Display alerts from backend if any
+      if (response && response.alerts && response.alerts.length > 0) {
+        setAlerts(
+          response.alerts.map(
+            (a) => `Alert: You have reached ${a.threshold}% of your ${a.category} budget (Usage: ${a.usage}%).`
+          )
+        )
+      } else {
+        setAlerts([])
+      }
+
       // Invalidate queries to refetch data
       queryClient.invalidateQueries({ queryKey: expenseKeys.all })
       queryClient.invalidateQueries({ queryKey: budgetKeys.all })
@@ -310,6 +277,7 @@ function Records() {
       const message =
         err?.response?.data?.message ?? err?.message ?? 'Update failed'
       setError(message)
+      setAlerts([])
       throw err
     }
   }
@@ -661,6 +629,15 @@ function Records() {
                 {error && (
                   <div className="p-4 rounded-2xl bg-rose-500/10 border border-rose-500/20 text-rose-500 text-sm">
                     {error}
+                  </div>
+                )}
+                {alerts.length > 0 && (
+                  <div className="space-y-1">
+                    {alerts.map((alert, idx) => (
+                      <p key={idx} className="p-4 rounded-2xl bg-amber-500/10 border border-amber-500/20 text-amber-500 text-sm font-medium">
+                        {alert}
+                      </p>
+                    ))}
                   </div>
                 )}
 

--- a/apps/frontend/src/pages/Records.jsx
+++ b/apps/frontend/src/pages/Records.jsx
@@ -340,6 +340,7 @@ function Records() {
 
   const handleUpdateBudget = async (id) => {
     setError('')
+    setAlerts([])
     const payload = budgetEdits[id]
     if (!payload) return
 
@@ -349,12 +350,24 @@ function Records() {
     }
 
     try {
-      await updateBudget(id, {
+      const response = await updateBudget(id, {
         ...payload,
         limit: Number(payload.limit),
         month: Number(payload.month),
         year: Number(payload.year),
       })
+
+      // Display alerts from backend if any
+      if (response && response.alerts && response.alerts.length > 0) {
+        setAlerts(
+          response.alerts.map(
+            (a) => `Alert: You have reached ${a.threshold}% of your ${a.category} budget (Usage: ${a.usage}%).`
+          )
+        )
+      } else {
+        setAlerts([])
+      }
+
       // Invalidate queries to refetch data
       queryClient.invalidateQueries({ queryKey: budgetKeys.all })
       queryClient.invalidateQueries({ queryKey: analyticsKeys.all })
@@ -362,6 +375,7 @@ function Records() {
       const message =
         err?.response?.data?.message ?? err?.message ?? 'Update failed'
       setError(message)
+      setAlerts([])
       throw err
     }
   }

--- a/apps/frontend/src/services/budgetService.js
+++ b/apps/frontend/src/services/budgetService.js
@@ -14,7 +14,8 @@ export async function createBudget(payload) {
 
 export async function updateBudget(id, payload) {
   const response = await api.put(`/budgets/${id}`, payload)
-  return response.data?.data ?? {}
+  // Return the full response data to include alerts field
+  return response.data ?? {}
 }
 
 export async function deleteBudget(id) {


### PR DESCRIPTION
## Summary
This PR brings `preview` up to `main` (12 commits). Combines feature work that's been merged into `preview` over the last few weeks with three follow-up fixes from a security/bug audit.

## Fixes from the audit (latest commits)

### `841507c` test: cover currency 400 errors and subscription PUT validation
- New `tests/currency.service.test.js` and `tests/subscription.validation.test.js` (17 cases). Full backend suite: 306 passing.

### `2a46e47` fix: budget date staleness, currency 400, subscription PUT validation
- **Budget date staleness** — `apps/frontend/src/pages/CreateEntries.jsx` previously froze `month`/`year` at module load via `const today = new Date()`. Replaced with `getInitialBudget()` so a long-lived SPA session past midnight uses today's date.
- **Unsupported currency → 400** — `convertToUSD` / `convertFromUSD` in `currency.service.js` now throw an `Error` carrying `statusCode = 400` and message `Unsupported currency: <code>`. The global error middleware turns this into a clean 400 instead of leaking 500 when the FX API doesn't know an ISO code.
- **PUT /subscriptions validation** — added `subscriptionUpdateSchema` (all fields optional, `.min(1)`, no `user` field). Wired into `subscription.routes.js` PUT route to block mass-assignment of ownership and reject unknown keys.

### `199a74b` fix: only print SMTP debug logs in non-production
- `[EMAIL_DEBUG]` lines in `apps/backend/src/config/email.js` are now gated on `NODE_ENV !== 'production'`, so SMTP user and the first 4 chars of the password no longer leak into prod logs.

## Other changes already on `preview`

### CI / infra
- **`163ea60`** point deploy workflows to new server.

### Subscriptions
- **`24bd707` / `89f9bf2`** add a `notes` field on subscriptions; the create form drops the `renewalDate` input (auto-derived in the service); backend model/validation/service tests updated.

### Currency
- **`c061472`** accept all 3-letter ISO currency codes across models and validations (budget/expense/income/subscription); 460-line `tests/currency.crud.test.js` added.

### Budgets & alerts
- **`0ad31a9`** backend budget alert processing on expense updates; frontend surfaces alerts.
- **`1f57fa4`** alerts also recomputed when a budget is edited.

### UX
- **`9eb85bf`** subscriptions/expenses/income date fields default to today via a helper.
- **`75cefbf`** changelog entry for v1.12.0.

## Follow-ups (filed as separate issues, not in this PR)
- [#50](https://github.com/1590703336/Barbie/issues/50) edit modal still has `renewalDate` UI while create flow dropped it
- [#51](https://github.com/1590703336/Barbie/issues/51) auth token in localStorage (XSS-readable)
- [#52](https://github.com/1590703336/Barbie/issues/52) login error messages enable account enumeration
- [#53](https://github.com/1590703336/Barbie/issues/53) auth/admin middleware leaks JWT error details
- [#54](https://github.com/1590703336/Barbie/issues/54) Arcjet bot detection blocks CI/curl globally
- [#55](https://github.com/1590703336/Barbie/issues/55) admin login lacks dedicated rate limit
- [#56](https://github.com/1590703336/Barbie/issues/56) admin `\$regex` search uses unescaped input (ReDoS)

## Test plan
- [x] Backend `npm test` — 306 pass / 2 skipped / 24 suites.
- [ ] Create / edit subscription with a non-USD ISO currency; confirm persistence and that an unsupported code returns **400 Unsupported currency** (not 500).
- [ ] PUT /subscriptions/:id with a `user` field is rejected (400). Partial PUT (e.g. just `name`) succeeds.
- [ ] Open Create Entries near midnight on a long-lived tab; confirm budget month/year reflect today.
- [ ] Trigger budget alert paths via expense and budget updates; confirm alerts on the frontend.
- [ ] In a non-prod env, `[EMAIL_DEBUG]` lines still appear; in production, they are suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)